### PR TITLE
fix: action attempts to close already closed issues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,10 @@ export async function processDiscussions(githubClient: GithubDiscussionClient) {
           core.warning(`Can not proceed checking discussion, discussionId is null!`);
           continue;
         }
+        else if (discussion?.node?.closed) {
+          core.debug(`Discussion ${discussionId} is closed, so no action needed.`);
+          continue;
+        }
         else if (discussion?.node?.locked && CLOSE_LOCKED_DISCUSSIONS) {
           core.info(`Discussion ${discussionId} is locked, closing it as resolved`);
           githubClient.closeDiscussionAsResolved(discussionId);
@@ -58,10 +62,6 @@ export async function processDiscussions(githubClient: GithubDiscussionClient) {
         else if (discussion?.node?.answer != null && CLOSE_ANSWERED_DISCUSSIONS) {
           core.info(`Discussion ${discussionId} is already answered, so closing it as resolved.`);
           githubClient.closeDiscussionAsResolved(discussionId);
-          continue;
-        }
-        else if (discussion?.node?.closed) {
-          core.debug(`Discussion ${discussionId} is closed, so no action needed.`);
           continue;
         }
         else {


### PR DESCRIPTION
The action is doing a ton of duplicate effort, check the [action logs in CDK repo](https://github.com/aws/aws-cdk/actions/runs/5466502727/jobs/9951520511), and the scheduled run tries to close the same discussions over and over again. This partially fixes duplicate effort by checking if the discussion is closed before checking if it's locked or answered

There's duplicate calls made elsewhere that this PR doesn't fix. One situation where this is likely to happen frequently is with the attention label - we should try to check if the label is already present on a discussion before attempting to add it. However if the tradeoff for that is that the graphql calls get too big, it's probably fine to leave as-is. Regardless of unnecessary calls made elsewhere, the fix this PR makes is a no-brainer and also easy

---

* [ ] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-github-ops/handle-stale-discussions/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
