### PR TITLE
fix: action.yml default cause unexpected behavior

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,22 +10,18 @@ inputs:
   attention-label:
     description: 'Label to add to stale discussions'
     required: false
-    default: 'attention'
   github-token:
     description: 'GitHub token'
     required: false
   days-until-stale:
     description: 'Number of days of inactivity before a discussion is considered stale'
     required: false
-    default: 7
   close-locked-discussions:
     description: 'Close locked discussions'
     required: false
-    default: true
   close-answered-discussions:
     description: 'Close answered discussions'
     required: false
-    default: true
   stale-response-text:
     description: 'Comment to post when marking a discussion as stale'
     required: false
@@ -35,16 +31,12 @@ inputs:
   proposed-answer-keyword:
     description: 'Keyword to use to indicate a proposed answer'
     required: false
-    default: '@github-actions proposed-answer'
   close-stale-as-answered:
     description: 'Close stale discussions as answered'
     required: false
-    default: false
   github-bot:
     description: 'Github action bot login name'
     required: false
-    default: 'github-actions'
   page-size:
     description: 'Page size count for discussions to be loaded per page'
     required: false
-    default: 50


### PR DESCRIPTION
Let's define our defaults in code, not in this file. Our workflows were still closing stale issues as outdated by default due to this in the `action.yml`

---

* [ ] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-github-ops/handle-stale-discussions/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
