### PR TITLE
fix: getBooleanInput requires input

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,10 @@ const PAGE_SIZE = parseInt(core.getInput('page-size', { required: false })) || 5
 const GITHUB_BOT = core.getInput('github-bot', { required: false}) || 'github-actions';
 const DAYS_UNTIL_STALE = parseFloat(core.getInput('days-until-stale', { required: false })) || 7;
 const PROPOSED_ANSWER_KEYWORD = core.getInput('proposed-answer-keyword', { required: false }) || '@github-actions proposed-answer';
-const CLOSE_LOCKED_DISCUSSIONS = core.getBooleanInput('close-locked-discussions', { required: false });
-const CLOSE_ANSWERED_DISCUSSIONS = core.getBooleanInput('close-answered-discussions', { required: false });
+const closeLockedDiscussionsInput = core.getInput('close-locked-discussions', { required: false });
+const CLOSE_LOCKED_DISCUSSIONS = closeLockedDiscussionsInput.toLowerCase() === 'true' ? true : false;
+const closeAnsweredDiscussionsInput = core.getInput('close-answered-discussions', { required: false });
+const CLOSE_ANSWERED_DISCUSSIONS = closeAnsweredDiscussionsInput.toLowerCase() === 'true' ? true : false;
 const closeStaleAsAnsweredInput = core.getInput('close-stale-as-answered', { required: false });
 const CLOSE_STALE_AS_ANSWERED = closeStaleAsAnsweredInput.toLowerCase() === 'false' ? false : true;
 const CLOSE_FOR_STALENESS_RESPONSE_TEXT = core.getInput('stale-response-text', { required: false })


### PR DESCRIPTION
Fixes issue where input was now required because that's how `getBooleanInput` works apparently

---

* [ ] Have you followed the guidelines in our [Contributing guide?](https://github.com/aws-github-ops/handle-stale-discussions/blob/main/CONTRIBUTING.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
